### PR TITLE
Added refresh button, prevent trades and orders book fetches in the positions tab

### DIFF
--- a/src/views/TradeView.vue
+++ b/src/views/TradeView.vue
@@ -3348,9 +3348,6 @@ watch(activeTab, async (newTab) => {
       await fetchDhanOrdersTradesBook();
     }
   }
-
-  // Update both orders and positions regardless of the active tab
-  await updateOrdersAndPositions();
 });
 
 // Watcher to update localStorage when enableHotKeys changes

--- a/src/views/TradeView.vue
+++ b/src/views/TradeView.vue
@@ -766,7 +766,7 @@
                 <th>Quantity</th>
                 <th>Price</th>
                 <th>Execution Time</th>
-                <th>Status</th>
+                <th>Status & Reason</th>
               </tr>
             </thead>
             <tbody>
@@ -777,10 +777,21 @@
                 <td>{{ dhanOrder.quantity }}</td>
                 <td>{{ dhanOrder.price }}</td>
                 <td>{{ dhanOrder.createTime }}</td>
-                <td>{{ dhanOrder.orderStatus }}</td>
+                <td :class="{
+                      'text-danger': dhanOrder.orderStatus === 'REJECTED',
+                      'text-warning': dhanOrder.orderStatus === 'PENDING' || dhanOrder.orderStatus === 'OPEN'
+                    }">
+                  {{ dhanOrder.orderStatus }}
+                  <span v-if="dhanOrder.orderStatus === 'REJECTED'" 
+                        class="ms-2" 
+                        data-bs-toggle="tooltip" 
+                        :title="dhanOrder.omsErrorDescription">
+                    ℹ️
+                  </span>
+                </td>
               </tr>
               <tr v-if="dhanOrders.length === 0">
-                <td colspan="6" class="text-center">No orders or trades on selected broker {{
+                <td colspan="7" class="text-center">No orders or trades on selected broker {{
                   selectedBroker.brokerName }}</td>
               </tr>
             </tbody>
@@ -817,7 +828,12 @@
                         'text-warning': item.order.status === 'PENDING' || item.order.status === 'OPEN'
                       }">
                         {{ item.order.status }}
-                        {{ item.order.rejreason }}
+                        <span v-if="item.order.status === 'REJECTED'" 
+                              class="ms-2" 
+                              data-bs-toggle="tooltip" 
+                              :title="item.order.rejreason">
+                          ℹ️
+                        </span>
                       </td>
                     </tr>
                     <tr v-if="item.trade" class="nested-trade-row">
@@ -874,7 +890,12 @@
                         'text-warning': item.order.status === 'PENDING' || item.order.status === 'OPEN'
                       }">
                         {{ item.order.status }}
-                        {{ item.order.rejreason }}
+                        <span v-if="item.order.status === 'REJECTED'" 
+                              class="ms-2" 
+                              data-bs-toggle="tooltip" 
+                              :title="item.order.rejreason">
+                          ℹ️
+                        </span>
                       </td>
                     </tr>
                     <tr v-if="item.trade" class="nested-trade-row">
@@ -1898,7 +1919,14 @@ const maskBrokerClientId = (clientId) => {
   return `${firstPart}${middleMask}${lastPart}`;
 };
 
-
+// Rejected Order tooltips...
+onMounted(() => {
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.map((tooltipTriggerEl) => {
+    return new bootstrap.Tooltip(tooltipTriggerEl);
+  });
+});
+  
 // Update the quantities object
 const quantities = ref({
   NIFTY: { lotSize: 25, maxLots: 10 },

--- a/src/views/TradeView.vue
+++ b/src/views/TradeView.vue
@@ -3296,8 +3296,12 @@ watch(
       debouncedUpdateSubscriptions();
 
       // Reset LTP values when subscribing to new symbols
-      latestCallLTP.value = 'N/A';
-      latestPutLTP.value = 'N/A';
+      if (newCallId !== oldCallId) {
+        latestCallLTP.value = 'N/A';
+      }
+      if (newPutId !== oldPutId) {
+        latestPutLTP.value = 'N/A';
+      }
 
       setFlattradeCredentials();
     }

--- a/src/views/TradeView.vue
+++ b/src/views/TradeView.vue
@@ -760,6 +760,7 @@
           <table class="table table-hover" v-if="activeFetchFunction === 'fetchDhanOrdersTradesBook'">
             <thead>
               <tr>
+                <th>Side</th>
                 <th>Order ID</th>
                 <th>Symbol</th>
                 <th>Quantity</th>
@@ -770,6 +771,7 @@
             </thead>
             <tbody>
               <tr v-for="dhanOrder in dhanOrders" :key="dhanOrder.orderId">
+                <td>{{ dhanOrder.transactionType }}</td>
                 <td>{{ dhanOrder.orderId }}</td>
                 <td>{{ dhanOrder.tradingSymbol }}</td>
                 <td>{{ dhanOrder.quantity }}</td>
@@ -789,6 +791,7 @@
               <thead>
                 <tr>
                   <th scope="col">Type</th>
+                  <th scope="col">Side</th>
                   <th scope="col">Details</th>
                   <th scope="col">Qty</th>
                   <th scope="col">Price</th>
@@ -801,6 +804,7 @@
                   <template v-for="item in combinedOrdersAndTrades" :key="item.norenordno">
                     <tr v-if="item.order.status !== 'COMPLETE'">
                       <td>Order</td>
+                      <td>{{ item.order.trantype }}</td>
                       <td>
                         {{ item.order.norenordno }}
                         {{ item.order.tsym }}
@@ -818,6 +822,7 @@
                     </tr>
                     <tr v-if="item.trade" class="nested-trade-row">
                       <td>Trade</td>
+                      <td>{{ item.trade.trantype }}</td>
                       <td>
                         {{ item.trade.norenordno }}
                         {{ item.trade.tsym }}
@@ -843,6 +848,7 @@
               <thead>
                 <tr>
                   <th scope="col">Type</th>
+                  <th scope="col">Side</th>
                   <th scope="col">Details</th>
                   <th scope="col">Qty</th>
                   <th scope="col">Price</th>
@@ -855,6 +861,7 @@
                   <template v-for="item in combinedOrdersAndTrades" :key="item.norenordno">
                     <tr v-if="item.order.status !== 'COMPLETE'">
                       <td>Order</td>
+                      <td>{{ item.order.trantype }}</td>
                       <td>
                         {{ item.order.norenordno }}
                         {{ item.order.tsym }}
@@ -872,6 +879,7 @@
                     </tr>
                     <tr v-if="item.trade" class="nested-trade-row">
                       <td>Trade</td>
+                      <td>{{ item.order.trantype }}</td>
                       <td>
                         {{ item.trade.norenordno }}
                         {{ item.trade.tsym }}

--- a/src/views/TradeView.vue
+++ b/src/views/TradeView.vue
@@ -466,6 +466,11 @@
             🤖 Automations
           </button>
         </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="refresh-tab" type="button" @click="refreshData">
+            🔄 Refresh
+          </button>
+        </li>	        
       </ul>
       <div class="tab-content" id="myTabContent">
         <div class="tab-pane fade show active" id="positions-tab-pane" role="tabpanel" aria-labelledby="positions-tab"
@@ -1155,7 +1160,27 @@ const updateSelectedBroker = () => {
     selectedBrokerName.value = '';
   }
 };
-
+  
+// Refresh selected tab...
+const refreshData = () => {
+  if (activeTab.value === 'trades') {
+    if (selectedBroker.value?.brokerName === 'Dhan') {
+      fetchDhanOrdersTradesBook();
+    } else if (selectedBroker.value?.brokerName === 'Flattrade') {
+      fetchFlattradeOrdersTradesBook();
+    } else if (selectedBroker.value?.brokerName === 'Shoonya') {
+      fetchShoonyaOrdersTradesBook();
+    }
+  } else if (activeTab.value === 'positions') {
+    if (selectedBroker.value?.brokerName === 'Dhan') {
+      fetchDhanPositions();
+    } else if (selectedBroker.value?.brokerName === 'Flattrade') {
+      fetchFlattradePositions();
+    } else if (selectedBroker.value?.brokerName === 'Shoonya') {
+      fetchShoonyaPositions();
+    }
+  }
+};
 
 // Fetch trading symbols and strikes
 const selectedExchange = ref({});


### PR DESCRIPTION
Trading directly through the broker terminal doesn’t update data automatically. To address this, a refresh button has been added to avoid needing to switch tabs for a refresh. The positions tab fetches trades and orders, but switching to the trades tab triggers another fetch. This commit prevents redundant fetching of trades and orders when switching to the positions tab.
